### PR TITLE
Update deprecated keyword keep_dims to keepdims

### DIFF
--- a/layers.py
+++ b/layers.py
@@ -297,7 +297,7 @@ class Forward(object):
         :param axis:
         :return:
         """
-        x_max = tf.reduce_max(x, axis=axis, keep_dims=True)
+        x_max = tf.reduce_max(x, axis=axis, keepdims=True)
         x_max_ = tf.reduce_max(x, axis=axis)
         return x_max_ + tf.log(tf.reduce_sum(tf.exp(x - x_max), axis=axis))
 


### PR DESCRIPTION
`keep_dims` is deprecated and will be removed.

```
WARNING:tensorflow:From /path/to/layers.py:300: calling reduce_max (from tensorflow.python.ops.math_ops) with keep_dims is deprecated and will be removed in a future version.
Instructions for updating:
keep_dims is deprecated, use keepdims instead
```

See also https://www.tensorflow.org/api_docs/python/tf/reduce_max